### PR TITLE
Add data for different platform (or use case)

### DIFF
--- a/spring-boot-test-demo/src/main/java/com/kucw/dao/UserDao.java
+++ b/spring-boot-test-demo/src/main/java/com/kucw/dao/UserDao.java
@@ -44,6 +44,6 @@ public class UserDao {
     }
 
     public void print() {
-        System.out.println("This is user dao");
+        namedParameterJdbcTemplate.query("SELECT * FROM user", new HashMap<>(), USER_MAPPER).forEach(System.out::println);
     }
 }

--- a/spring-boot-test-demo/src/test/java/com/kucw/dao/UserDaoWithPredefinedDataTest.java
+++ b/spring-boot-test-demo/src/test/java/com/kucw/dao/UserDaoWithPredefinedDataTest.java
@@ -1,0 +1,30 @@
+package com.kucw.dao;
+
+import com.kucw.model.User;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+@ActiveProfiles("5566")
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class UserDaoWithPredefinedDataTest {
+
+    @Autowired
+    private UserDao userDao;
+
+
+    @Test
+    public void find5566() throws Exception {
+        userDao.print();
+        Assert.assertEquals("5566不能亡", userDao.getUserById(5566).getName());
+    }
+
+}

--- a/spring-boot-test-demo/src/test/resources/application-5566.properties
+++ b/spring-boot-test-demo/src/test/resources/application-5566.properties
@@ -1,0 +1,3 @@
+
+spring.datasource.platform=5566
+#spring.datasource.initialization-mode=always


### PR DESCRIPTION
https://docs.spring.io/spring-boot/docs/2.1.6.RELEASE/reference/html/howto-database-initialization.html

1. 透過 `@ActiveProfiles` 對特定的 test case 啟用 profile `5566`
2. 在當 profile 被啟用後，除了原本預設的 application.properties，會再將 `application-5566.properties` 的設定 patch 上去
3. 利用 2. 的效果，追加要讀取的 `data-5566.sql`

## 結果範例

* 因為預設的 schema.sql 與 data.sql 都會被載入，會看到 2 筆資料。
* 如果不想要有 2 筆，那麼在 default profile 也可以設定 platform，讓它預設不是使用 `data.sql`

![image](https://user-images.githubusercontent.com/193223/75692797-05a02600-5ce1-11ea-853d-b096eed57d39.png)

PS. 比較意外的，default 的 data.sql 沒有先執行
